### PR TITLE
Workaround Chrome's jank focus logic

### DIFF
--- a/internal/outcome-tree.js
+++ b/internal/outcome-tree.js
@@ -8,7 +8,8 @@ class OutcomeTree extends LocalizedLitElement {
 	
 	static get properties() {
 		return {
-			_focusedNode: { type: OutcomeTreeNode }
+			_focusedNode: { type: OutcomeTreeNode },
+			_hasFocus: { type: Boolean, value: false }
 		};
 	}
 	
@@ -34,6 +35,11 @@ class OutcomeTree extends LocalizedLitElement {
 		];
 	}
 	
+	firstUpdated( changedProperties ) {
+		super.firstUpdated( changedProperties );
+		this.addEventListener( 'blur', () => { this._hasFocus = false; } );
+	}
+	
 	updated( changedProperties ) {
 		super.updated( changedProperties );
 		const firstNode = this._getFirstNode();
@@ -57,15 +63,17 @@ class OutcomeTree extends LocalizedLitElement {
 			activeDescendant = this._focusedNode.htmlId;
 		}
 		
+		const tabIndex = (Browser.isChrome() && this._hasFocus) ? -1 : 0;
 		return html`
 			<div class="outcomes-tree">
 				<ul
 					id="tree-root"
 					role="tree"
 					aria-activedescendant="${ifDefined(activeDescendant)}"
-					tabindex="0"
+					tabindex="${tabIndex}"
 					@keydown="${this._onKeyDown}"
 					@focus="${this._onFocus}"
+					@blur="${this._onBlur}"
 				>
 					${this._renderTree()}
 				</ul>
@@ -80,6 +88,7 @@ class OutcomeTree extends LocalizedLitElement {
 	}
 	
 	_onFocus() {
+		this._hasFocus = true;
 		if( !Browser.isSafari() && this._focusedNode ) {
 			this._focusedNode._focusNode();
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-program-outcomes-picker",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "scripts": {
     "lang:build": "lang-build -edc langtools/config.json",
     "lang:copy": "lang-copy -svc langtools/config.json",


### PR DESCRIPTION
So apparently Chrome will cause a webcomponent's focus method to be fired sometimes when one of its children receives focus while the component is _already_ focused, and this causes the focus to get locked due to our logic to refocus the last selected node when focusing the tree. Other browsers don't have this problem because that's not how focus is supposed to work.

My workaround is to set the tabindex of the tree to -1 (not keyboard focusable) while it is already focused so it can't try to double-focus itself, but then set it back to 0 once the tree is no longer in focus.

BSI Build to test on:
https://s.brightspace.com/lib/bsi/dev/4b4de8cf2de6cd64061dee5afae2cddfa2643d17/